### PR TITLE
fix: #46 use libdisplay-info_0_3 when available

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1785104993,
-        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1785002762,
-        "narHash": "sha256-Y0BbgB3BLLHEUK88g4oSp3DerIx7rCX0iwICKJcY7/c=",
+        "lastModified": 1785104993,
+        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f7a2e428f5d71c47a5a938a3c5ad7138bb291093",
+        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
           seatd,
           libinput,
           libxkbcommon,
+          libdisplay-info_0_3 ? libdisplay-info,
           libdisplay-info,
           pango,
           withDbus ? true,
@@ -97,6 +98,7 @@
           runCommand,
 
         }:
+        assert libdisplay-info_0_3.version == "0.3.0";
         rustPlatform.buildRustPackage {
           pname = "niri";
           version = package-version src;
@@ -118,7 +120,7 @@
             libglvnd
             seatd
             libinput
-            libdisplay-info
+            libdisplay-info_0_3
             libxkbcommon
             pango
           ]


### PR DESCRIPTION
Fixes build error under recent Nixpkgs changes while maintaining compatibility with older branches.

It uses a similar approach to the previous time this issue happened: https://github.com/epireyn/niri-flake/commit/9e59ee80bf92a02423e7ca7b301f969fe230c8d8

This is an alternative to and will close #47.
