### PR TITLE
homeModules.config: disable HM wayland.windowManager.niri

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -447,6 +447,8 @@
             target = "niri/config.kdl";
             source = validated-config-for pkgs cfg.package cfg.finalConfig;
           };
+
+          disabledModules = [ "services/window-managers/niri.nix" ];
         };
       nixosModules.niri =
         {


### PR DESCRIPTION
https://github.com/nix-community/home-manager/pull/9685
Doesn't technically conflict, but not clean to have both of them.