### PR TITLE
feat: Add layer match to layer-rules

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -4289,7 +4289,7 @@ When true, this rule will match layer surfaces opened within the first 60 second
 - type: `null or one of "background", "bottom", "top", "overlay"`
 - default: `null`
 
-An enum specifiying a layer-shell layer to match. Avaliable options "background", "bottom", "top", "overlay".
+Matches surfaces on this layer-shell layer.
 
 
 ## `programs.niri.settings.layer-rules.*.excludes`
@@ -4322,7 +4322,7 @@ When true, this rule will match layer surfaces opened within the first 60 second
 - type: `null or one of "background", "bottom", "top", "overlay"`
 - default: `null`
 
-An enum specifiying a layer-shell layer to match. Avaliable options "background", "bottom", "top", "overlay".
+Matches surfaces on this layer-shell layer.
 
 
 ## `programs.niri.settings.layer-rules.*.block-out-from`

--- a/docs.md
+++ b/docs.md
@@ -4285,6 +4285,13 @@ All layer surfaces have a namespace set once at creation. When this rule is non-
 When true, this rule will match layer surfaces opened within the first 60 seconds of niri starting up. When false, this rule will match layer surfaces opened *more than* 60 seconds after niri started up. This is useful for applying different rules to layer surfaces opened from [`spawn-at-startup`](#programsnirisettingsspawn-at-startup) versus those opened later.
 
 
+## `programs.niri.settings.layer-rules.*.matches.*.layer`
+- type: `null or one of "background", "bottom", "top", "overlay"`
+- default: `null`
+
+An enum specifiying a layer-shell layer to match. Avaliable options "background", "bottom", "top", "overlay".
+
+
 ## `programs.niri.settings.layer-rules.*.excludes`
 - type: `list of (match rule)`
 
@@ -4309,6 +4316,13 @@ All layer surfaces have a namespace set once at creation. When this rule is non-
 - default: `null`
 
 When true, this rule will match layer surfaces opened within the first 60 seconds of niri starting up. When false, this rule will match layer surfaces opened *more than* 60 seconds after niri started up. This is useful for applying different rules to layer surfaces opened from [`spawn-at-startup`](#programsnirisettingsspawn-at-startup) versus those opened later.
+
+
+## `programs.niri.settings.layer-rules.*.excludes.*.layer`
+- type: `null or one of "background", "bottom", "top", "overlay"`
+- default: `null`
+
+An enum specifiying a layer-shell layer to match. Avaliable options "background", "bottom", "top", "overlay".
 
 
 ## `programs.niri.settings.layer-rules.*.block-out-from`

--- a/settings.nix
+++ b/settings.nix
@@ -2886,6 +2886,13 @@
                   ];
                 };
 
+                layers = types.enum [
+                  "background"
+                  "bottom"
+                  "top"
+                  "overlay"
+                ];
+
                 layer-match = ordered-record' "match rule" [
                   {
                     namespace = nullable regex // {
@@ -2899,6 +2906,13 @@
                   {
                     at-startup = nullable types.bool // {
                       description = layer-rule-descriptions.match-at-startup;
+                    };
+                  }
+                  {
+                    layer = nullable layers // {
+                      description = ''
+                        An enum specifiying a layer-shell layer to match. Avaliable options "background", "bottom", "top", "overlay".
+                      '';
                     };
                   }
                 ];

--- a/settings.nix
+++ b/settings.nix
@@ -2911,7 +2911,7 @@
                   {
                     layer = nullable layers // {
                       description = ''
-                        An enum specifiying a layer-shell layer to match. Avaliable options "background", "bottom", "top", "overlay".
+                        Matches surfaces on this layer-shell layer.
                       '';
                     };
                   }


### PR DESCRIPTION
Introduction of `layer` match rule added in niri 26.04.

Apologies if the documentation I added isn't good or doesn't match the rest of the docs.